### PR TITLE
Fix code scanning alert no. 13: Reflected server-side cross-site scripting

### DIFF
--- a/packages/examples-flask-started/src/blueprints/_02_registering/__init__.py
+++ b/packages/examples-flask-started/src/blueprints/_02_registering/__init__.py
@@ -1,11 +1,11 @@
-from flask import Blueprint, request
+from flask import Blueprint, request, escape
 
 registering = Blueprint("registering", __name__, url_prefix="/registering")
 
 
 @registering.route("/")
 def root() -> str:
-    return f"{request.url} was called.\n"
+    return f"{escape(request.url)} was called.\n"
 
 
 none = Blueprint("registering", __name__)
@@ -15,7 +15,7 @@ registering.register_blueprint(none)
 @none.route("/")
 def index_none() -> str:
     """Nothing specified."""
-    return f"{request.url} was called.\n"
+    return f"{escape(request.url)} was called.\n"
 
 
 when_declaring = Blueprint("when_declaring", __name__, url_prefix="/when-declaring")
@@ -25,7 +25,7 @@ registering.register_blueprint(when_declaring)
 @when_declaring.route("/")
 def index_when_declaring() -> str:
     """Specify the url_prefix when declaring."""
-    return f"{request.url} was called.\n"
+    return f"{escape(request.url)} was called.\n"
 
 
 when_registering = Blueprint("when_registering", __name__)
@@ -35,7 +35,7 @@ registering.register_blueprint(when_registering, url_prefix="/when-registering")
 @when_registering.route("/")
 def index_when_registering() -> str:
     """Specify the url_prefix when registering."""
-    return f"{request.url} was called.\n"
+    return f"{escape(request.url)} was called.\n"
 
 
 different = Blueprint("different", __name__, url_prefix="/different-when-declared")
@@ -45,4 +45,4 @@ registering.register_blueprint(different, url_prefix="/different-when-registered
 @different.route("/")
 def index_different() -> str:
     """The url_prefix at the time of registration will be used."""
-    return f"{request.url} was called.\n"
+    return f"{escape(request.url)} was called.\n"


### PR DESCRIPTION
Fixes [https://github.com/suzu-devworks/examples-py-web/security/code-scanning/13](https://github.com/suzu-devworks/examples-py-web/security/code-scanning/13)

To fix the problem, we need to escape the user-provided input before including it in the response. In this case, we can use the `escape` function from the `flask` module to sanitize the `request.url` before using it in the response. This will ensure that any potentially malicious content in the URL is properly escaped and cannot execute as a script.

We will modify the return statements in the affected routes to use `escape(request.url)` instead of `request.url`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
