### PR TITLE
Potential fix for code scanning alert no. 19: Binding a socket to all network interfaces

### DIFF
--- a/packages/examples-flask-media/tools/udp_echo.py
+++ b/packages/examples-flask-media/tools/udp_echo.py
@@ -1,7 +1,7 @@
 import os
 import socket
 
-UDP_IP = "0.0.0.0"
+UDP_IP = "127.0.0.1"
 
 
 def main() -> None:


### PR DESCRIPTION
Potential fix for [https://github.com/suzu-devworks/examples-py-web/security/code-scanning/19](https://github.com/suzu-devworks/examples-py-web/security/code-scanning/19)

The best way to fix this problem is to refrain from binding the UDP socket to all interfaces. Instead, bind it only to a dedicated and intended interface (loopback or a specific external IP). For a local UDP echo server that does not need to be accessible from remote machines, it's generally safest to bind to the loopback address (`"127.0.0.1"`), which will only accept packets from processes running on the same machine. This change should be made by replacing the assignment of the `UDP_IP` constant at line 4, changing its value from `"0.0.0.0"` to `"127.0.0.1"`. As there are no special imports or additional logic required, this is a self-contained change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
